### PR TITLE
enable fancy symbols like ♥ and ó by using a compose key

### DIFF
--- a/keymaps/usaswe
+++ b/keymaps/usaswe
@@ -7,6 +7,7 @@ xkb_symbols "usaswe" {
   include "latin(basic)"
   include "level3(ralt_switch)"
   include "capslock(swapescape)"
+  include "compose(rctrl)"
 
   key <AC11> { [ apostrophe,  quotedbl,  adiaeresis, Adiaeresis ] };
   key <AC10> { [ semicolon,   colon,     odiaeresis, Odiaeresis ] };


### PR DESCRIPTION
Holding down right ctrl and then typing '<' followed by '3' results in '♥'.
Fancy, huh?
