### PR TITLE
Include 'compose(rctrl)' after Swedish characters

### DIFF
--- a/keymaps/usaswe
+++ b/keymaps/usaswe
@@ -7,9 +7,10 @@ xkb_symbols "usaswe" {
   include "latin(basic)"
   include "level3(ralt_switch)"
   include "capslock(swapescape)"
-  include "compose(rctrl)"
 
   key <AC11> { [ apostrophe,  quotedbl,  adiaeresis, Adiaeresis ] };
   key <AC10> { [ semicolon,   colon,     odiaeresis, Odiaeresis ] };
   key <AD11> { [ bracketleft, braceleft, aring,      Aring      ] };
+
+  include "compose(rctrl)"
 };


### PR DESCRIPTION
If `compose(rctrl)` is included before the Swedish characters the compose key won't work.
